### PR TITLE
#163073601 Make failing config tests pass

### DIFF
--- a/=4.2b1
+++ b/=4.2b1
@@ -1,0 +1,1 @@
+Requirement already satisfied: PyYAML in /home/phs/.virtualenvs/myenv/lib/python3.6/site-packages (3.13)

--- a/instance/config.py
+++ b/instance/config.py
@@ -1,0 +1,36 @@
+import os
+'''Configuration files for the API'''
+
+class Config(object):
+    '''Parent configuration class'''
+    DEBUG = False
+    CSRF_ENABLED = True
+    SECRET_KEY = 'thisismysecretkeywhydontyouuseyours'
+
+
+class DevelopmentConfig(Config):
+    '''configurations for development environment'''
+    DEBUG = True
+    TESTING = True
+
+class StagingConfig(Config):
+    '''configurations for staging environment'''
+    DEBUG = True
+
+class TestingConfig(Config):
+    '''configurations for staging environment'''
+    DEBUG = True
+    TESTING = True
+
+class ProductionConfig(Config):
+    '''configurations for production environment'''
+    DEBUG = False
+    TESTING = False
+
+
+app_config = {
+    'development': DevelopmentConfig,
+    'staging': StagingConfig,
+    'production': ProductionConfig,
+    'testing': TestingConfig,
+}


### PR DESCRIPTION
**What does this PR do?**
Enables a user to run passing tests for the main project configuration 

**Description of the tasks to be achieved**
Have the following goals achieved:
- make the failing tests for the project configuration pass
- implement the tests using the unittest framework

**How should this be manually tested?**

1. clone the git repo http://github.com/dennisdnyce/Questioner.git on your project folder.

2. cd Questioner

3. git checkout ch-challenge2-failing-config-tests-163073601

4. install and activate the virtual environment

5. install and run pytest

**What are the relevant pivotal tracker stories?**
#163073601

**Screenshots**
![passconfig](https://user-images.githubusercontent.com/23360985/50865289-252a1000-13b6-11e9-861f-92b8358e7cef.png)
